### PR TITLE
makes use of ErrNotFound for GET /properties/:name

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"ImportPath": "github.com/syndtr/goleveldb/leveldb",
-			"Rev": "4875955338b0a434238a31165cb87255ab6e9e4a"
+			"Rev": "012f65f74744ed62a80abac6e9a8c86e71c2b6fa"
 		},
 		{
 			"ImportPath": "github.com/syndtr/gosnappy/snappy",

--- a/Godeps/_workspace/src/github.com/syndtr/goleveldb/leveldb/db.go
+++ b/Godeps/_workspace/src/github.com/syndtr/goleveldb/leveldb/db.go
@@ -784,7 +784,7 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 
 	const prefix = "leveldb."
 	if !strings.HasPrefix(name, prefix) {
-		return "", errors.New("leveldb: GetProperty: unknown property: " + name)
+		return "", ErrNotFound
 	}
 	p := name[len(prefix):]
 
@@ -798,7 +798,7 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 		var rest string
 		n, _ := fmt.Sscanf(p[len(numFilesPrefix):], "%d%s", &level, &rest)
 		if n != 1 || int(level) >= db.s.o.GetNumLevel() {
-			err = errors.New("leveldb: GetProperty: invalid property: " + name)
+			err = ErrNotFound
 		} else {
 			value = fmt.Sprint(v.tLen(int(level)))
 		}
@@ -837,7 +837,7 @@ func (db *DB) GetProperty(name string) (value string, err error) {
 	case p == "aliveiters":
 		value = fmt.Sprintf("%d", atomic.LoadInt32(&db.aliveIters))
 	default:
-		err = errors.New("leveldb: GetProperty: unknown property: " + name)
+		err = ErrNotFound
 	}
 
 	return

--- a/libldbrest/endpoints.go
+++ b/libldbrest/endpoints.go
@@ -183,10 +183,12 @@ func batchSetItems(w http.ResponseWriter, r *http.Request, p httprouter.Params) 
 
 // get a leveldb property
 func getLDBProperty(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-	prop, err := db.GetProperty(p.ByName("name"))
-	// TODO: differentiate between "property doesn't exist"
-	if err != nil {
+	name := p.ByName("name")
+	prop, err := db.GetProperty(name)
+	if err == leveldb.ErrNotFound {
 		failCode(w, http.StatusNotFound)
+	} else if err != nil {
+		failErr(w, err)
 	} else {
 		w.Header().Set("Content-Type", "text/plain")
 		w.Write([]byte(prop))


### PR DESCRIPTION
updates goleveldb to a version that returns ErrNotFound, and looks for
it in the /properties/:name endpoint.
